### PR TITLE
Add simple HTML project manager app

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Checklist Pro</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="p-4">
+  <h1 class="mb-4">Checklist Pro</h1>
+
+  <div class="mb-3">
+    <input id="taskName" class="form-control mb-2" placeholder="Tarea" />
+    <div class="row g-2 mb-2">
+      <div class="col">
+        <select id="taskPriority" class="form-select">
+          <option value="Alta">Alta</option>
+          <option value="Media" selected>Media</option>
+          <option value="Baja">Baja</option>
+        </select>
+      </div>
+      <div class="col">
+        <select id="taskStatus" class="form-select">
+          <option value="Por hacer">Por hacer</option>
+          <option value="En progreso">En progreso</option>
+          <option value="Completada">Completada</option>
+        </select>
+      </div>
+      <div class="col">
+        <input type="date" id="taskDue" class="form-control" />
+      </div>
+    </div>
+    <button id="addTaskBtn" class="btn btn-primary">Añadir tarea</button>
+    <button id="exportCsvBtn" class="btn btn-secondary ms-2">Exportar CSV</button>
+    <label class="btn btn-secondary ms-2 mb-0">
+      Importar JSON
+      <input type="file" id="importJsonInput" accept="application/json" hidden />
+    </label>
+  </div>
+
+  <table class="table table-bordered" id="taskTable">
+    <thead>
+      <tr>
+        <th>Tarea</th>
+        <th>Prioridad</th>
+        <th>Estado</th>
+        <th>Fecha límite</th>
+        <th>Acciones</th>
+      </tr>
+    </thead>
+    <tbody></tbody>
+  </table>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/web/script.js
+++ b/web/script.js
@@ -1,0 +1,103 @@
+let tasks = [];
+
+function loadTasks() {
+  const stored = localStorage.getItem('tasks');
+  tasks = stored ? JSON.parse(stored) : [];
+}
+
+function saveTasks() {
+  localStorage.setItem('tasks', JSON.stringify(tasks));
+}
+
+function renderTasks() {
+  const tbody = document.querySelector('#taskTable tbody');
+  tbody.innerHTML = '';
+  tasks.forEach((t, i) => {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `
+      <td>${t.name}</td>
+      <td>${t.priority}</td>
+      <td>${t.status}</td>
+      <td>${t.due || ''}</td>
+      <td>
+        <button class="btn btn-sm btn-outline-primary me-1" data-index="${i}" data-action="edit">Editar</button>
+        <button class="btn btn-sm btn-outline-danger" data-index="${i}" data-action="delete">Eliminar</button>
+      </td>`;
+    tbody.appendChild(tr);
+  });
+}
+
+function addTask() {
+  const name = document.getElementById('taskName').value.trim();
+  const priority = document.getElementById('taskPriority').value;
+  const status = document.getElementById('taskStatus').value;
+  const due = document.getElementById('taskDue').value;
+  if (!name) return;
+  tasks.push({ name, priority, status, due });
+  saveTasks();
+  renderTasks();
+  document.getElementById('taskName').value = '';
+  document.getElementById('taskDue').value = '';
+}
+
+function handleTableClick(e) {
+  if (!e.target.dataset.action) return;
+  const idx = e.target.dataset.index;
+  const task = tasks[idx];
+  if (e.target.dataset.action === 'delete') {
+    tasks.splice(idx, 1);
+  } else if (e.target.dataset.action === 'edit') {
+    const name = prompt('Tarea', task.name);
+    if (name === null) return;
+    const priority = prompt('Prioridad (Alta, Media, Baja)', task.priority);
+    if (priority === null) return;
+    const status = prompt('Estado (Por hacer, En progreso, Completada)', task.status);
+    if (status === null) return;
+    const due = prompt('Fecha límite (YYYY-MM-DD)', task.due);
+    tasks[idx] = { name, priority, status, due };
+  }
+  saveTasks();
+  renderTasks();
+}
+
+function exportCsv() {
+  const headers = ['Tarea', 'Prioridad', 'Estado', 'Fecha limite'];
+  const rows = tasks.map(t => [t.name, t.priority, t.status, t.due]);
+  const csvContent = [headers, ...rows].map(r => r.map(v => `"${v || ''}"`).join(',')).join('\n');
+  const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = 'tasks.csv';
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+function importJson(file) {
+  const reader = new FileReader();
+  reader.onload = e => {
+    try {
+      const imported = JSON.parse(e.target.result);
+      if (Array.isArray(imported)) {
+        tasks = tasks.concat(imported);
+        saveTasks();
+        renderTasks();
+      }
+    } catch (err) {
+      alert('Archivo JSON inválido');
+    }
+  };
+  reader.readAsText(file);
+}
+
+document.getElementById('addTaskBtn').addEventListener('click', addTask);
+document.getElementById('taskTable').addEventListener('click', handleTableClick);
+document.getElementById('exportCsvBtn').addEventListener('click', exportCsv);
+document.getElementById('importJsonInput').addEventListener('change', e => {
+  const file = e.target.files[0];
+  if (file) importJson(file);
+  e.target.value = '';
+});
+
+loadTasks();
+renderTasks();


### PR DESCRIPTION
## Summary
- add web-based task manager with Bootstrap UI
- handle task persistence with localStorage
- support CSV export and JSON import

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68abb8d373f8832bab2fc32e3f66cf4e